### PR TITLE
Feature/upload to releasename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ github-assets-uploader
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+/vendor/

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Command line tool to robustly upload Github release assets.
 
 ## Features
 - Upload file to Github Release Assets that identified by `tag`.    
-- Allow `overwrite` if file exists.    
+- Allow `overwrite` if file exists.
+- With the optional `-draft` flag an upload to an existing draft-release is supported (first pick)
 
 ## Build 
 ```bash
@@ -27,6 +28,8 @@ Usage of ./github-assets-uploader:
         Github repo, e.g., 'wangyoucao577/assets-uploader'.
   -tag string
         Git tag to identify a Github Release in repo.
+  -draft bool
+        Upload asset to an existing draft release.
   -token string
         Github token to make changes.
   -version

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Command line tool to robustly upload Github release assets.
 ## Features
 - Upload file to Github Release Assets that identified by `tag`.    
 - Allow `overwrite` if file exists.
-- With the optional `-draft` flag an upload to an existing draft-release is supported (first pick)
+- With the optional `-releasename` flag an upload to the newest existing release by name (e.g. a draft one)
 
 ## Build 
 ```bash
@@ -28,8 +28,8 @@ Usage of ./github-assets-uploader:
         Github repo, e.g., 'wangyoucao577/assets-uploader'.
   -tag string
         Git tag to identify a Github Release in repo.
-  -draft bool
-        Upload asset to an existing draft release.
+  -releasename string
+        Upload an asset to the newest existing release by name.
   -token string
         Github token to make changes.
   -version

--- a/cmd/github-assets-uploader/flags.go
+++ b/cmd/github-assets-uploader/flags.go
@@ -6,22 +6,22 @@ import (
 )
 
 type uploaderFlags struct {
-	draft     bool
-	file      string
-	mediaType string
-	overwrite bool
-	repo      string // e.g., wangyoucao577/assets-uploader
-	retry     uint
-	tag       string
-	token     string
+	file        string
+	mediaType   string
+	overwrite   bool
+	releaseName string
+	repo        string // e.g., wangyoucao577/assets-uploader
+	retry       uint
+	tag         string
+	token       string
 }
 
 func (u *uploaderFlags) validate() error {
 	if len(u.repo) == 0 {
 		return fmt.Errorf("repo is mandatory but not set")
 	}
-	if !u.draft && len(u.tag) == 0 {
-		return fmt.Errorf("tag is mandatory but not set")
+	if u.tag == "" && u.releaseName == "" {
+		return fmt.Errorf("tag or releasename is mandatory but not set")
 	}
 	if len(u.file) == 0 {
 		return fmt.Errorf("file is mandatory but not set")
@@ -36,10 +36,10 @@ func (u *uploaderFlags) validate() error {
 var flags uploaderFlags
 
 func init() {
-	flag.BoolVar(&flags.draft, "draft", false, "Upload asset to an existing draft release.")
 	flag.StringVar(&flags.file, "f", "", "File path to upload.")
 	flag.StringVar(&flags.mediaType, "mediatype", "application/gzip", "E.g., 'application/zip'.")
 	flag.BoolVar(&flags.overwrite, "overwrite", false, "Overwrite release asset if it's already exist.")
+	flag.StringVar(&flags.releaseName, "releasename", "", "Upload asset to an existing named release.")
 	flag.StringVar(&flags.repo, "repo", "", "Github repo, e.g., 'wangyoucao577/assets-uploader'.")
 	flag.StringVar(&flags.tag, "tag", "", "Git tag to identify a Github Release in repo.")
 	flag.UintVar(&flags.retry, "retry", 1, "How many times to retry if error occur.")

--- a/cmd/github-assets-uploader/flags.go
+++ b/cmd/github-assets-uploader/flags.go
@@ -6,20 +6,21 @@ import (
 )
 
 type uploaderFlags struct {
+	draft     bool
 	file      string
 	mediaType string
+	overwrite bool
 	repo      string // e.g., wangyoucao577/assets-uploader
+	retry     uint
 	tag       string
 	token     string
-	overwrite bool
-	retry     uint
 }
 
 func (u *uploaderFlags) validate() error {
 	if len(u.repo) == 0 {
 		return fmt.Errorf("repo is mandatory but not set")
 	}
-	if len(u.tag) == 0 {
+	if !u.draft && len(u.tag) == 0 {
 		return fmt.Errorf("tag is mandatory but not set")
 	}
 	if len(u.file) == 0 {
@@ -35,11 +36,12 @@ func (u *uploaderFlags) validate() error {
 var flags uploaderFlags
 
 func init() {
+	flag.BoolVar(&flags.draft, "draft", false, "Upload asset to an existing draft release.")
 	flag.StringVar(&flags.file, "f", "", "File path to upload.")
 	flag.StringVar(&flags.mediaType, "mediatype", "application/gzip", "E.g., 'application/zip'.")
+	flag.BoolVar(&flags.overwrite, "overwrite", false, "Overwrite release asset if it's already exist.")
 	flag.StringVar(&flags.repo, "repo", "", "Github repo, e.g., 'wangyoucao577/assets-uploader'.")
 	flag.StringVar(&flags.tag, "tag", "", "Git tag to identify a Github Release in repo.")
-	flag.StringVar(&flags.token, "token", "", "Github token to make changes.")
-	flag.BoolVar(&flags.overwrite, "overwrite", false, "Overwrite release asset if it's already exist.")
 	flag.UintVar(&flags.retry, "retry", 1, "How many times to retry if error occur.")
+	flag.StringVar(&flags.token, "token", "", "Github token to make changes.")
 }

--- a/cmd/github-assets-uploader/main.go
+++ b/cmd/github-assets-uploader/main.go
@@ -81,7 +81,7 @@ func uploadAsset(repoOwner, repoName, tag, assetPath, mediaType, token string, o
 	if tag != "" {
 		release, _, err = client.Repositories.GetReleaseByTag(rwContext, repoOwner, repoName, tag)
 	} else if flags.releaseName != "" {
-		release, err = getDraftRelease(rwContext, client, repoOwner, repoName)
+		release, err = getReleaseByName(rwContext, client, repoOwner, repoName, flags.releaseName)
 	}
 
 	if err != nil {
@@ -128,7 +128,8 @@ func uploadAsset(repoOwner, repoName, tag, assetPath, mediaType, token string, o
 	return nil
 }
 
-func getDraftRelease(ctx context.Context, client *github.Client, repoOwner, repoName string) (*github.RepositoryRelease, error) {
+// getReleaseByName lists all releases, sort them by created-at and picks the first/newest one with the given name.
+func getReleaseByName(ctx context.Context, client *github.Client, repoOwner, repoName, releaseName string) (*github.RepositoryRelease, error) {
 	releases, _, err := client.Repositories.ListReleases(ctx, repoOwner, repoName, nil)
 	if err != nil {
 		return nil, err
@@ -139,9 +140,9 @@ func getDraftRelease(ctx context.Context, client *github.Client, repoOwner, repo
 	})
 
 	for _, release := range releases { // assume they are some kind of sorted, first pick (newest)
-		if release.GetName() == flags.releaseName {
+		if release.GetName() == releaseName {
 			return release, nil
 		}
 	}
-	return nil, fmt.Errorf("no release found with name: %q", flags.releaseName)
+	return nil, fmt.Errorf("no release found with name: %q", releaseName)
 }

--- a/cmd/github-assets-uploader/main.go
+++ b/cmd/github-assets-uploader/main.go
@@ -9,11 +9,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/wangyoucao577/assets-uploader/util/appversion"
-
 	"github.com/golang/glog"
 	"github.com/google/go-github/v39/github"
 	"golang.org/x/oauth2"
+
+	"github.com/wangyoucao577/assets-uploader/util/appversion"
 )
 
 func errExit(err error) {
@@ -45,6 +45,7 @@ func main() {
 	}
 
 	retry := flags.retry
+	retryDuration := time.Second * 3
 	for {
 		retry--
 
@@ -53,8 +54,8 @@ func main() {
 			if retry == 0 {
 				errExit(err)
 			} else {
-				glog.Warningf("Upload asset error, will retry soon: %v\n", err)
-				time.Sleep(3 * time.Second) // retry after 3 seconds
+				glog.Warningf("Upload asset error, will retry in %s: %v\n", retryDuration.String(), err)
+				time.Sleep(retryDuration) // retry after 3 seconds
 				continue
 			}
 		}

--- a/cmd/github-assets-uploader/main.go
+++ b/cmd/github-assets-uploader/main.go
@@ -48,7 +48,7 @@ func main() {
 	for {
 		retry--
 
-		err := uploadAsset(repoOwner, repoName, flags.tag, flags.file, flags.mediaType, flags.token, flags.overwrite)
+		err = uploadAsset(repoOwner, repoName, flags.tag, flags.file, flags.mediaType, flags.token, flags.overwrite)
 		if err != nil {
 			if retry == 0 {
 				errExit(err)

--- a/cmd/github-assets-uploader/main.go
+++ b/cmd/github-assets-uploader/main.go
@@ -65,22 +65,39 @@ func main() {
 }
 
 func uploadAsset(repoOwner, repoName, tag, assetPath, mediaType, token string, overwrite bool) error {
-
 	// read-write client
-	rwContext := context.Background()
+	rwContext, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
 	tc := oauth2.NewClient(rwContext, ts)
 	client := github.NewClient(tc)
 
+	var draftRelease, release *github.RepositoryRelease
+	var err error
+	var releaseID int64
+
+	if flags.draft {
+		draftRelease, err = getDraftRelease(rwContext, client, repoOwner, repoName)
+		if err != nil {
+			return err
+		}
+		releaseID = draftRelease.GetID()
+	}
+
 	// get release by tag
-	release, _, err := client.Repositories.GetReleaseByTag(context.Background(), repoOwner, repoName, tag)
-	if err != nil {
-		return err
+	if draftRelease == nil {
+		release, _, err = client.Repositories.GetReleaseByTag(rwContext, repoOwner, repoName, tag)
+		if err != nil {
+			return err
+		}
+		releaseID = release.GetID()
 	}
 
 	assetName := filepath.Base(assetPath)
 	if overwrite { // remove old one if it's exist already
-		assets, _, err := client.Repositories.ListReleaseAssets(context.Background(), repoOwner, repoName, release.GetID(), nil)
+		var assets []*github.ReleaseAsset
+		assets, _, err = client.Repositories.ListReleaseAssets(rwContext, repoOwner, repoName, releaseID, nil)
 		if err != nil {
 			return err
 		}
@@ -88,7 +105,7 @@ func uploadAsset(repoOwner, repoName, tag, assetPath, mediaType, token string, o
 			if asset.GetName() == assetName {
 
 				// found exist one, delete it
-				if _, err := client.Repositories.DeleteReleaseAsset(rwContext, repoOwner, repoName, asset.GetID()); err != nil {
+				if _, err = client.Repositories.DeleteReleaseAsset(rwContext, repoOwner, repoName, asset.GetID()); err != nil {
 					return err
 				}
 				glog.Infof("Deleted old asset, id %d, name '%s', url '%s'\n", asset.GetID(), asset.GetName(), asset.GetBrowserDownloadURL())
@@ -105,7 +122,7 @@ func uploadAsset(repoOwner, repoName, tag, assetPath, mediaType, token string, o
 	defer f.Close()
 
 	// upload
-	releaseAsset, _, err := client.Repositories.UploadReleaseAsset(rwContext, repoOwner, repoName, release.GetID(), &github.UploadOptions{
+	releaseAsset, _, err := client.Repositories.UploadReleaseAsset(rwContext, repoOwner, repoName, releaseID, &github.UploadOptions{
 		Name:      assetName,
 		Label:     "",
 		MediaType: mediaType,
@@ -115,4 +132,20 @@ func uploadAsset(repoOwner, repoName, tag, assetPath, mediaType, token string, o
 	}
 	glog.Infof("Upload asset succeed, id %d, name '%s', url: '%s'\n", releaseAsset.GetID(), releaseAsset.GetName(), releaseAsset.GetBrowserDownloadURL())
 	return nil
+}
+
+func getDraftRelease(ctx context.Context, client *github.Client, repoOwner, repoName string) (*github.RepositoryRelease, error) {
+	releases, _, err := client.Repositories.ListReleases(ctx, repoOwner, repoName, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var draftRelease *github.RepositoryRelease
+	for _, release := range releases { // assume they are some kind of sorted, first pick (newest)
+		if release.GetDraft() {
+			draftRelease = release
+			break
+		}
+	}
+	return draftRelease, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/wangyoucao577/assets-uploader
 go 1.15
 
 require (
-	github.com/golang/glog v1.0.0 // indirect
+	github.com/golang/glog v1.0.0
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-github/v39 v39.2.0
 	golang.org/x/net v0.0.0-20211109214657-ef0fda0de508 // indirect


### PR DESCRIPTION
This PR adds an option to upload the given file asset to an existing draft release.

Prevent mailing users for (pre)release events without assets. Enables reaction to build fails before release promotion.

Would be nice if we could propagate this `-draft` option to https://github.com/wangyoucao577/go-release-action .